### PR TITLE
Add alternative name

### DIFF
--- a/Thrustmaster-TA320-Pilot.xml
+++ b/Thrustmaster-TA320-Pilot.xml
@@ -2,6 +2,7 @@
 
 <PropertyList>
     <name type="string">Thrustmaster T.A320 Pilot</name>
+    <name type="string">T.A320 Pilot</name>
     
     <nasal>
         <script><![CDATA[

--- a/Thrustmaster-TCA-Q-Eng-1&2.xml
+++ b/Thrustmaster-TCA-Q-Eng-1&2.xml
@@ -2,7 +2,8 @@
 
 <PropertyList>
     <name type="string">Thrustmaster TCA Q-Eng 1&amp;2</name>
-    
+    <name type="string">TCA Q-Eng 1&amp;2</name>
+
     <nasal>
         <script><![CDATA[
             if (globals['tca'] == nil) {


### PR DESCRIPTION
Hello!

First of all, thank you for sharing your joystick configuration!

In order for my joystick to be recognized I had to add the name it had on my system to the xmls.

Being new to FlightGear, I was quite confused by the Joystick not being detected. Maybe it can help others in my situation if the config file supports both names.